### PR TITLE
Add deploy badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # HealthyStartChildCare.com
 
+[![Deploy to Cloudflare Pages](https://github.com/MrMatt57/HealthyStartChildCare.com/actions/workflows/deploy.yml/badge.svg)](https://github.com/MrMatt57/HealthyStartChildCare.com/actions/workflows/deploy.yml)
+[![CodeQL](https://github.com/MrMatt57/HealthyStartChildCare.com/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/MrMatt57/HealthyStartChildCare.com/actions/workflows/github-code-scanning/codeql)
+
 Family child care website for Healthy Start Child Care in Westminster, MD.
 
 ## Tech Stack
 
 - Static HTML, CSS, vanilla JavaScript (no frameworks or build step)
 - Hosted on [Cloudflare Pages](https://pages.cloudflare.com/) (free tier)
-- Auto-deploys from `master` branch via Cloudflare GitHub integration
+- Auto-deploys from `main` branch via GitHub Actions
 
 ## Development
 
@@ -18,8 +21,8 @@ npx serve .
 
 ## Deployment
 
-Cloudflare Pages automatically deploys on push to `master`:
-- **Production**: `master` branch → healthystartchildcare.com
+Cloudflare Pages automatically deploys on push to `main`:
+- **Production**: `main` branch → healthystartchildcare.com
 - **Preview**: Every pull request gets a preview deployment URL
 
 ### Setup (one-time)


### PR DESCRIPTION
## Summary

- Add Cloudflare Pages deploy status badge
- Keep existing CodeQL badge
- Fix stale `master` references to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)